### PR TITLE
Fix connection caching bug

### DIFF
--- a/server/src/api.py
+++ b/server/src/api.py
@@ -25,7 +25,7 @@ async def get_task(task_id: str) -> dict:
 
 @app.post("/yt-videos/analyze")
 async def analyze_sentiments_of_video(body: PostBodyYtVideoAnalyze) -> dict:
-    task = analyze_comments.delay(body.yt_video_it)
+    task = analyze_comments.delay(body.yt_video_id)
 
     return {"task_id": task.id}
 

--- a/server/src/models/requests/post_yt_video_analyze.py
+++ b/server/src/models/requests/post_yt_video_analyze.py
@@ -2,4 +2,4 @@ from pydantic import BaseModel
 
 
 class PostBodyYtVideoAnalyze(BaseModel):
-    yt_video_it: str
+    yt_video_id: str

--- a/server/src/services/database_service.py
+++ b/server/src/services/database_service.py
@@ -35,10 +35,10 @@ class DatabaseService:
                         return []
 
     async def __get_conn(self) -> AsyncConnection:
-        if getattr(self, "__con", None):
+        if getattr(self, "__conn", None):
             return self.__conn
 
-        self.__con = await AsyncConnection.connect(
+        self.__conn = await AsyncConnection.connect(
             dbname=os.environ["POSTGRES_DB"],
             user=os.environ["POSTGRES_USER"],
             password=os.environ["POSTGRES_PASSWORD"],
@@ -46,4 +46,4 @@ class DatabaseService:
             port=os.environ["POSTGRES_PORT"],
         )
 
-        return self.__con
+        return self.__conn


### PR DESCRIPTION
## Summary
- correct DB connection singleton logic
- rename request field `yt_video_it` to `yt_video_id`
- update API to use the new field

## Testing
- `PYTHONPATH=server pytest -q` *(fails: ModuleNotFoundError: No module named 'stringcase')*

------
https://chatgpt.com/codex/tasks/task_e_68443a7c3748832ca338009b03b39707