### PR TITLE
Add basic landing page for Next.js frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 __pycache__
 .pytest_cache
 .vscode
+
+# Front dependencies
+front/node_modules

--- a/front/README.md
+++ b/front/README.md
@@ -1,4 +1,15 @@
-### 1. Launch the web interface
+# Sentitube Frontend
+
+This directory contains a small Next.js application used as a placeholder UI. It was created for Next.js **15.3.3** with TypeScript.
+
+## Development
+
+Install dependencies and start the development server:
+
 ```bash
-streamlit run app.py
+npm install
+npm run dev
 ```
+
+The default route now displays a simple landing page with a search bar and a call
+to action. Mocked sentiment analysis results remain available at `/results`.

--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -1,0 +1,47 @@
+export default function Landing() {
+  return (
+    <main style={{ padding: '2rem', fontFamily: 'sans-serif', textAlign: 'center' }}>
+      <h1
+        style={{
+          fontSize: '3rem',
+          fontWeight: 'bold',
+          background: 'linear-gradient(90deg, red, white)',
+          WebkitBackgroundClip: 'text',
+          WebkitTextFillColor: 'transparent',
+          marginBottom: '2rem',
+        }}
+      >
+        Sentitube
+      </h1>
+      <form style={{ display: 'flex', justifyContent: 'center', gap: '0.5rem' }}>
+        <input
+          type="text"
+          placeholder="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+          style={{ flex: '1 0 300px', padding: '0.5rem', fontSize: '1rem' }}
+        />
+        <button
+          type="submit"
+          style={{
+            padding: '0.5rem 1rem',
+            backgroundColor: '#ff0000',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            fontSize: '1rem',
+            cursor: 'pointer',
+          }}
+        >
+          Lancer l'analyse
+        </button>
+      </form>
+      <section style={{ marginTop: '2rem', maxWidth: '600px', marginLeft: 'auto', marginRight: 'auto' }}>
+        <p>
+          Sentitube analyse en temps réel les commentaires YouTube afin de vous
+          donner un aperçu clair de l'opinion des spectateurs. Entrez simplement
+          l'URL d'une vidéo pour découvrir si le ressenti est plutôt positif,
+          neutre ou négatif.
+        </p>
+      </section>
+    </main>
+  )
+}

--- a/front/app/results/page.tsx
+++ b/front/app/results/page.tsx
@@ -1,0 +1,40 @@
+export default function Home() {
+  const analyses = [
+    {
+      yt_comment_id: '1',
+      yt_comment_text: 'Great video, loved it!',
+      sentiment_score: 0.8,
+      justification: 'It expresses very positive feelings about the video.',
+    },
+    {
+      yt_comment_id: '2',
+      yt_comment_text: 'I did not like the sound quality.',
+      sentiment_score: -0.4,
+      justification: 'It states a clear negative opinion.',
+    },
+    {
+      yt_comment_id: '3',
+      yt_comment_text: 'Nice, thanks for sharing.',
+      sentiment_score: 0.5,
+      justification: 'The comment is appreciative though short.',
+    },
+  ]
+
+  return (
+    <main style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
+      <h1>Sentiment analyses</h1>
+      <ul style={{ listStyle: 'none', padding: 0 }}>
+        {analyses.map((a) => (
+          <li
+            key={a.yt_comment_id}
+            style={{ border: '1px solid #ccc', marginTop: '1rem', padding: '1rem' }}
+          >
+            <p><strong>Comment:</strong> {a.yt_comment_text}</p>
+            <p><strong>Score:</strong> {a.sentiment_score}</p>
+            <p><strong>Justification:</strong> {a.justification}</p>
+          </li>
+        ))}
+      </ul>
+    </main>
+  )
+}

--- a/front/next-env.d.ts
+++ b/front/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/front/package.json
+++ b/front/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "sentitube-front",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "15.3.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5",
+    "@types/react": "18.2.40",
+    "@types/node": "20.11.19"
+  }
+}

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "types": ["node"],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- move existing sentiment results page to `/results`
- create a simple landing page with a search bar and CTA
- update frontend README for the new landing page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68443accefa4832cb40bbeeb6328209c