### PR TITLE
Add basic landing page for Next.js frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 __pycache__
 .pytest_cache
 .vscode
+
+# Front dependencies
+front/node_modules

--- a/front/README.md
+++ b/front/README.md
@@ -1,4 +1,15 @@
-### 1. Launch the web interface
+# Sentitube Frontend
+
+This directory contains a small Next.js application used as a placeholder UI. It was created for Next.js **15.3.3** with TypeScript.
+
+## Development
+
+Install dependencies and start the development server:
+
 ```bash
-streamlit run app.py
+npm install
+npm run dev
 ```
+
+The default route now displays a simple landing page with a search bar and a call
+to action. Mocked sentiment analysis results remain available at `/results`.

--- a/front/README.md
+++ b/front/README.md
@@ -11,5 +11,7 @@ npm install
 npm run dev
 ```
 
-The default route now displays a simple landing page with a search bar and a call
-to action. Mocked sentiment analysis results remain available at `/results`.
+This frontend uses Tailwind CSS. The default route is a simple landing page with
+a search bar and call to action. Mocked sentiment analysis results remain
+available at `/results`.
+

--- a/front/app/globals.css
+++ b/front/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/front/app/layout.tsx
+++ b/front/app/layout.tsx
@@ -1,0 +1,15 @@
+import './globals.css'
+import type { ReactNode } from 'react'
+
+export const metadata = {
+  title: 'Sentitube',
+  description: 'Analyse de sentiment pour YouTube',
+}
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="fr">
+      <body className="min-h-screen bg-gray-50 text-gray-900">{children}</body>
+    </html>
+  )
+}

--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -1,40 +1,23 @@
 export default function Landing() {
   return (
-    <main style={{ padding: '2rem', fontFamily: 'sans-serif', textAlign: 'center' }}>
-      <h1
-        style={{
-          fontSize: '3rem',
-          fontWeight: 'bold',
-          background: 'linear-gradient(90deg, red, white)',
-          WebkitBackgroundClip: 'text',
-          WebkitTextFillColor: 'transparent',
-          marginBottom: '2rem',
-        }}
-      >
+    <main className="flex flex-col items-center p-8 text-center space-y-6">
+      <h1 className="text-5xl font-extrabold bg-gradient-to-r from-red-600 via-red-300 to-white bg-clip-text text-transparent">
         Sentitube
       </h1>
-      <form style={{ display: 'flex', justifyContent: 'center', gap: '0.5rem' }}>
+      <form className="flex w-full max-w-xl gap-2">
         <input
           type="text"
           placeholder="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-          style={{ flex: '1 0 300px', padding: '0.5rem', fontSize: '1rem' }}
+          className="flex-grow rounded-md border border-gray-300 px-3 py-2 text-base"
         />
         <button
           type="submit"
-          style={{
-            padding: '0.5rem 1rem',
-            backgroundColor: '#ff0000',
-            color: 'white',
-            border: 'none',
-            borderRadius: '4px',
-            fontSize: '1rem',
-            cursor: 'pointer',
-          }}
+          className="rounded-md bg-red-600 px-4 py-2 text-white hover:bg-red-700"
         >
           Lancer l'analyse
         </button>
       </form>
-      <section style={{ marginTop: '2rem', maxWidth: '600px', marginLeft: 'auto', marginRight: 'auto' }}>
+      <section className="max-w-xl text-gray-700">
         <p>
           Sentitube analyse en temps réel les commentaires YouTube afin de vous
           donner un aperçu clair de l'opinion des spectateurs. Entrez simplement

--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -1,0 +1,47 @@
+export default function Landing() {
+  return (
+    <main style={{ padding: '2rem', fontFamily: 'sans-serif', textAlign: 'center' }}>
+      <h1
+        style={{
+          fontSize: '3rem',
+          fontWeight: 'bold',
+          background: 'linear-gradient(90deg, red, white)',
+          WebkitBackgroundClip: 'text',
+          WebkitTextFillColor: 'transparent',
+          marginBottom: '2rem',
+        }}
+      >
+        Sentitube
+      </h1>
+      <form style={{ display: 'flex', justifyContent: 'center', gap: '0.5rem' }}>
+        <input
+          type="text"
+          placeholder="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+          style={{ flex: '1 0 300px', padding: '0.5rem', fontSize: '1rem' }}
+        />
+        <button
+          type="submit"
+          style={{
+            padding: '0.5rem 1rem',
+            backgroundColor: '#ff0000',
+            color: 'white',
+            border: 'none',
+            borderRadius: '4px',
+            fontSize: '1rem',
+            cursor: 'pointer',
+          }}
+        >
+          Lancer l'analyse
+        </button>
+      </form>
+      <section style={{ marginTop: '2rem', maxWidth: '600px', marginLeft: 'auto', marginRight: 'auto' }}>
+        <p>
+          Sentitube analyse en temps réel les commentaires YouTube afin de vous
+          donner un aperçu clair de l'opinion des spectateurs. Entrez simplement
+          l'URL d'une vidéo pour découvrir si le ressenti est plutôt positif,
+          neutre ou négatif.
+        </p>
+      </section>
+    </main>
+  )
+}

--- a/front/app/results/page.tsx
+++ b/front/app/results/page.tsx
@@ -1,0 +1,40 @@
+export default function Home() {
+  const analyses = [
+    {
+      yt_comment_id: '1',
+      yt_comment_text: 'Great video, loved it!',
+      sentiment_score: 0.8,
+      justification: 'It expresses very positive feelings about the video.',
+    },
+    {
+      yt_comment_id: '2',
+      yt_comment_text: 'I did not like the sound quality.',
+      sentiment_score: -0.4,
+      justification: 'It states a clear negative opinion.',
+    },
+    {
+      yt_comment_id: '3',
+      yt_comment_text: 'Nice, thanks for sharing.',
+      sentiment_score: 0.5,
+      justification: 'The comment is appreciative though short.',
+    },
+  ]
+
+  return (
+    <main style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
+      <h1>Sentiment analyses</h1>
+      <ul style={{ listStyle: 'none', padding: 0 }}>
+        {analyses.map((a) => (
+          <li
+            key={a.yt_comment_id}
+            style={{ border: '1px solid #ccc', marginTop: '1rem', padding: '1rem' }}
+          >
+            <p><strong>Comment:</strong> {a.yt_comment_text}</p>
+            <p><strong>Score:</strong> {a.sentiment_score}</p>
+            <p><strong>Justification:</strong> {a.justification}</p>
+          </li>
+        ))}
+      </ul>
+    </main>
+  )
+}

--- a/front/app/results/page.tsx
+++ b/front/app/results/page.tsx
@@ -1,4 +1,4 @@
-export default function Home() {
+export default function Results() {
   const analyses = [
     {
       yt_comment_id: '1',
@@ -21,17 +21,20 @@ export default function Home() {
   ]
 
   return (
-    <main style={{ padding: '2rem', fontFamily: 'sans-serif' }}>
-      <h1>Sentiment analyses</h1>
-      <ul style={{ listStyle: 'none', padding: 0 }}>
+    <main className="p-8 space-y-4">
+      <h1 className="text-2xl font-semibold">Analyses fictives</h1>
+      <ul className="space-y-4">
         {analyses.map((a) => (
-          <li
-            key={a.yt_comment_id}
-            style={{ border: '1px solid #ccc', marginTop: '1rem', padding: '1rem' }}
-          >
-            <p><strong>Comment:</strong> {a.yt_comment_text}</p>
-            <p><strong>Score:</strong> {a.sentiment_score}</p>
-            <p><strong>Justification:</strong> {a.justification}</p>
+          <li key={a.yt_comment_id} className="rounded-md border p-4">
+            <p>
+              <strong>Commentaire:</strong> {a.yt_comment_text}
+            </p>
+            <p>
+              <strong>Score:</strong> {a.sentiment_score}
+            </p>
+            <p>
+              <strong>Justification:</strong> {a.justification}
+            </p>
           </li>
         ))}
       </ul>

--- a/front/next-env.d.ts
+++ b/front/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/front/next.config.js
+++ b/front/next.config.js
@@ -1,0 +1,4 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {}
+
+module.exports = nextConfig

--- a/front/package.json
+++ b/front/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "sentitube-front",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "15.3.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.4.5",
+    "@types/react": "18.2.40",
+    "@types/node": "20.11.19"
+  }
+}

--- a/front/package.json
+++ b/front/package.json
@@ -15,6 +15,9 @@
   "devDependencies": {
     "typescript": "5.4.5",
     "@types/react": "18.2.40",
-    "@types/node": "20.11.19"
+    "@types/node": "20.11.19",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.38",
+    "autoprefixer": "^10.4.16"
   }
 }

--- a/front/postcss.config.js
+++ b/front/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/front/tailwind.config.js
+++ b/front/tailwind.config.js
@@ -1,0 +1,8 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ['./app/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "types": ["node"],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- move existing sentiment results page to `/results`
- create a simple landing page with a search bar and CTA
- update frontend README for the new landing page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68443accefa4832cb40bbeeb6328209c