### PR TITLE
Improve landing page design

### DIFF
--- a/front/app/globals.css
+++ b/front/app/globals.css
@@ -1,3 +1,20 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer utilities {
+  @keyframes shake {
+    0%, 100% {
+      transform: translateX(0);
+    }
+    25% {
+      transform: translateX(-4px);
+    }
+    75% {
+      transform: translateX(4px);
+    }
+  }
+  .animate-shake {
+    animation: shake 0.3s linear;
+  }
+}

--- a/front/app/layout.tsx
+++ b/front/app/layout.tsx
@@ -9,7 +9,9 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="fr">
-      <body className="min-h-screen bg-gray-50 text-gray-900">{children}</body>
+      <body className="min-h-screen bg-gradient-to-b from-gray-50 to-gray-200 text-gray-900">
+        {children}
+      </body>
     </html>
   )
 }

--- a/front/app/page.tsx
+++ b/front/app/page.tsx
@@ -1,29 +1,107 @@
+"use client"
+
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+
 export default function Landing() {
+  const router = useRouter()
+  const [url, setUrl] = useState("")
+  const [error, setError] = useState(false)
+
+  const validate = (input: string) => {
+    const regex = /^(https?:\/\/)?(www\.)?(youtube\.com\/watch\?v=|youtu\.be\/)[\w-]{11}/
+    return regex.test(input.trim())
+  }
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!validate(url)) {
+      setError(true)
+      return
+    }
+    setError(false)
+    router.push("/results")
+  }
+
   return (
-    <main className="flex flex-col items-center p-8 text-center space-y-6">
-      <h1 className="text-5xl font-extrabold bg-gradient-to-r from-red-600 via-red-300 to-white bg-clip-text text-transparent">
+    <main className="flex flex-col items-center p-8 text-center space-y-10">
+      <h1 className="text-6xl md:text-7xl font-extrabold bg-gradient-to-r from-red-700 via-red-500 to-red-400 bg-clip-text text-transparent drop-shadow-sm">
         Sentitube
       </h1>
-      <form className="flex w-full max-w-xl gap-2">
-        <input
-          type="text"
-          placeholder="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
-          className="flex-grow rounded-md border border-gray-300 px-3 py-2 text-base"
-        />
-        <button
-          type="submit"
-          className="rounded-md bg-red-600 px-4 py-2 text-white hover:bg-red-700"
-        >
-          Lancer l'analyse
-        </button>
+      <form onSubmit={onSubmit} className="flex w-full max-w-xl flex-col gap-2">
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+            className={`flex-grow rounded-md border px-3 py-2 text-base shadow-sm focus:outline-none focus:ring-2 focus:ring-red-500 ${
+              error ? "border-red-600 animate-shake" : "border-gray-300"
+            }`}
+          />
+          <button
+            type="submit"
+            className="rounded-md bg-red-600 px-4 py-2 font-medium text-white transition-colors hover:bg-red-700"
+          >
+            Lancer l'analyse
+          </button>
+        </div>
+        {error && (
+          <p className="text-left text-sm text-red-600">URL YouTube invalide</p>
+        )}
       </form>
-      <section className="max-w-xl text-gray-700">
-        <p>
-          Sentitube analyse en temps réel les commentaires YouTube afin de vous
-          donner un aperçu clair de l'opinion des spectateurs. Entrez simplement
-          l'URL d'une vidéo pour découvrir si le ressenti est plutôt positif,
-          neutre ou négatif.
+      <section className="max-w-xl text-gray-700 space-y-6">
+        <p className="text-lg font-medium">
+          Analysez instantanément le ressenti des spectateurs grâce à notre outil
+          de sentiment AI pour YouTube.
         </p>
+        <ul className="grid gap-4 sm:grid-cols-3">
+          <li className="flex flex-col items-center space-y-2">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="h-8 w-8 text-red-600"
+            >
+              <path
+                fillRule="evenodd"
+                d="M2.25 12a9.75 9.75 0 1119.5 0 9.75 9.75 0 01-19.5 0zm14.72-2.28a.75.75 0 00-1.06-1.06L10.5 14.06l-2.41-2.41a.75.75 0 00-1.06 1.06l3 3a.75.75 0 001.06 0l6.93-6.93z"
+                clipRule="evenodd"
+              />
+            </svg>
+            <span className="text-sm">Analyse instantanée</span>
+          </li>
+          <li className="flex flex-col items-center space-y-2">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="h-8 w-8 text-red-600"
+            >
+              <path
+                fillRule="evenodd"
+                d="M2.25 4.5A2.25 2.25 0 014.5 2.25h15a2.25 2.25 0 012.25 2.25v15A2.25 2.25 0 0119.5 21.75h-15A2.25 2.25 0 012.25 19.5v-15zM6 7.5a.75.75 0 000 1.5h12a.75.75 0 000-1.5H6zm0 4.5a.75.75 0 000 1.5h12a.75.75 0 000-1.5H6zm0 4.5a.75.75 0 000 1.5h7.5a.75.75 0 000-1.5H6z"
+                clipRule="evenodd"
+              />
+            </svg>
+            <span className="text-sm">Rapports clairs</span>
+          </li>
+          <li className="flex flex-col items-center space-y-2">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              className="h-8 w-8 text-red-600"
+            >
+              <path
+                fillRule="evenodd"
+                d="M12 2.25a.75.75 0 01.75.75v8.25h8.25a.75.75 0 010 1.5h-8.25v8.25a.75.75 0 01-1.5 0v-8.25H3.75a.75.75 0 010-1.5h8.25V3a.75.75 0 01.75-.75z"
+                clipRule="evenodd"
+              />
+            </svg>
+            <span className="text-sm">Gratuit et open-source</span>
+          </li>
+        </ul>
       </section>
     </main>
   )


### PR DESCRIPTION
## Summary
- redesign landing page with bigger title, new gradient and error handling
- animate the input on error
- add gradient background on layout
- define custom shake animation
- add SaaS-style feature section with icons

## Testing
- `poetry run pytest -q` *(fails: ModuleNotFoundError)*
- `poetry install --no-interaction` *(fails: could not connect to pypi.org)*
- `npm --prefix front run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844433ab7d8832c954b2acadc524abc